### PR TITLE
QUICK_START.md example broken due to `bfshi/AutoGaze` no longer existing

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -13,8 +13,8 @@ from autogaze.datasets.video_utils import read_video_pyav, transform_video_for_p
 from autogaze.models.autogaze import AutoGazeImageProcessor, AutoGaze
 
 # Load AutoGaze model and its preprocessor from HuggingFace
-autogaze_transform = AutoGazeImageProcessor.from_pretrained("bfshi/AutoGaze")
-autogaze_model = AutoGaze.from_pretrained("bfshi/AutoGaze")
+autogaze_transform = AutoGazeImageProcessor.from_pretrained("nvidia/AutoGaze")
+autogaze_model = AutoGaze.from_pretrained("nvidia/AutoGaze")
 
 # Load a video
 video_path = "<path_to_autogaze_code>/assets/example_input.mp4"  # Fill in the path of AutoGaze codebase
@@ -92,7 +92,7 @@ Let's take SigLIP2-SO400M with 384x384 input resolution and 14x14 patch size as 
 
 ```python
 # Load AutoGaze preprocessor with size of 392
-autogaze_392_transform = AutoGazeImageProcessor.from_pretrained("bfshi/AutoGaze", size=(392, 392))
+autogaze_392_transform = AutoGazeImageProcessor.from_pretrained("nvidia/AutoGaze", size=(392, 392))
 
 # Preprocess the video with AutoGaze preprocessor
 video_input_autogaze_392 = transform_video_for_pytorch(raw_video, autogaze_392_transform)  # T * C * H * W


### PR DESCRIPTION
The `QUICK_START.md` code is broken because `bfshi/AutoGaze` no longer exists on Hugging Face. I assume @bfshi used to keep it on their personal account before it got moved to` nvidia/AutoGaze`.
<img width="640" height="344" alt="nvidia" src="https://github.com/user-attachments/assets/cad45e64-6128-4857-8d43-1cf51f4e47ae" />

I checked all other links to @bfshi HuggingFace account here like in `TRAIN.md` there's  `bfshi/VideoMAE_AutoGaze`, `bfshi/AutoGaze-Training-Data`, `bfshi/HLVid` and in 
 the model now lives at `nvidia/AutoGaze`, so the from_pretrained calls in the quick-start examples fail with a 404.

Note: the same stale ID also breaks `AutoProcessor.from_pretrained("nvidia/NVILA-8B-HD-Video")` — `preprocessor_config.json` ([L27](https://huggingface.co/nvidia/NVILA-8B-HD-Video/blob/main/preprocessor_config.json#L27)) and the default in `processing_nvila.py` ([L145](https://huggingface.co/nvidia/NVILA-8B-HD-Video/blob/main/processing_nvila.py#L145)) still reference `bfshi/AutoGaze`. I'm opening a companion PR on the Hub for that.
